### PR TITLE
Fix : fix getBoard response

### DIFF
--- a/server/9in/src/main/java/com/inProject/in/domain/Comment/Dto/RequestCommentDto.java
+++ b/server/9in/src/main/java/com/inProject/in/domain/Comment/Dto/RequestCommentDto.java
@@ -13,6 +13,7 @@ import lombok.*;
 public class RequestCommentDto {
     private Long user_id;
     private Long board_id;   //추후에 순환참조 문제 발생 시 이것으로 교체.
+    private String username;
     private String text;
 
     public Comment toEntity(User user, Board board){
@@ -21,11 +22,13 @@ public class RequestCommentDto {
                 .user(user)
                 .board(board)
                 .text(text)
+                .username(user.getUsername())
                 .build();
     }
 
     public RequestCommentDto(Comment comment){
         this.user_id = comment.getUser().getId();
+        this.username = comment.getUsername();
         this.board_id = comment.getBoard().getId();
         this.text = comment.getText();
     }

--- a/server/9in/src/main/java/com/inProject/in/domain/Comment/Dto/ResponseCommentDto.java
+++ b/server/9in/src/main/java/com/inProject/in/domain/Comment/Dto/ResponseCommentDto.java
@@ -11,12 +11,14 @@ import lombok.*;
 public class ResponseCommentDto {
     private Long comment_id;
     private Long user_id;
+    private String username;
     private Long board_id;
     private String text;
 
     public ResponseCommentDto(Comment comment){
         this.comment_id = comment.getId();
         this.user_id = comment.getUser().getId();
+        this.username = comment.getUsername();
         this.board_id = comment.getBoard().getId();
         this.text = comment.getText();
     }

--- a/server/9in/src/main/java/com/inProject/in/domain/Comment/entity/Comment.java
+++ b/server/9in/src/main/java/com/inProject/in/domain/Comment/entity/Comment.java
@@ -25,6 +25,8 @@ public class Comment extends BaseEntity {
     private Long id;
     @Column(nullable = false)
     private String text;
+    @Column(nullable = false)
+    private String username;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")       //N : 1
     private User user;


### PR DESCRIPTION
getboard 시 response에 있는 요소 수정
commentlist는 이제 username도 담아서 반환
responseinfoinboarddto는 이제 닉네임이 아닌 username을 반환하도록 함. myinfo의 유무 상관없이.